### PR TITLE
Use dictsort filter instead of .items() for consistent ordering.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,7 @@ galaxy_info:
         - buster   # 10
     - name: Ubuntu
       versions:
-        - disco
+        - focal
         - bionic
   # galaxy_tags:
   #   - tag_name

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -44,8 +44,8 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
   # Ubuntu
-  - name: ${TOX_ENVNAME}-ubuntu19
-    image: krzysztofmagosa/ubuntu19.04-ansible-compat
+  - name: ${TOX_ENVNAME}-ubuntu20
+    image: krzysztofmagosa/ubuntu20.04-ansible-compat
     pre_build_image: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/templates/ipsec.conf.j2
+++ b/templates/ipsec.conf.j2
@@ -1,8 +1,8 @@
 {{ ansible_managed | comment }}
 
-{% for name, conn in strongswan_conns.items() %}
+{% for name, conn in strongswan_conns | dictsort %}
 conn {{ name }}
-{% for key, value in conn.items() %}
+{% for key, value in conn | dictsort %}
     {{ key }}={% if value is boolean %}{{ value | ternary("yes", "no") }}{% else %}{{ value }}{% endif %}
 
 {% endfor %}


### PR DESCRIPTION
Depending on python version used, .items() doesn't reliably sort in ansible. Use dictsort filter to guarantee reliable ordering and thus idempotency when ipsec.conf template is rendered.